### PR TITLE
feat: product_serializer category 이름도 넘어가도록 수정

### DIFF
--- a/product/serializers/product_serializer.py
+++ b/product/serializers/product_serializer.py
@@ -1,23 +1,58 @@
 from rest_framework.serializers import ModelSerializer
 
-from product.models import Product
-
+from product.models import Category, Product
 from tag.serializers import TagSerializer
+
+
+class CategorySerializer(ModelSerializer):
+    """Serializer definition for Category Model"""
+
+    model = Category
+    fields = ["name"]
+    read_only_fields = ["name"]
+
 
 class ProductSerializer(ModelSerializer):
     """Serializer definition for Product Model."""
 
     tags = TagSerializer(
-        read_only = False,
-        many = True,
+        read_only=False,
+        many=True,
+    )
+
+    category = CategorySerializer(
+        read_only=True,
+        many=False,
     )
 
     class Meta:
         """Meta definition for ProductSerializer."""
 
         model = Product
-        fields = ["id", "name", "producer", "feedback_cnt", "review_cnt",
-                  "visit_cnt", "thumbnail_url", "rate_sum", "rate", "tags"]
+        fields = [
+            "id",
+            "name",
+            "producer",
+            "category",
+            "feedback_cnt",
+            "review_cnt",
+            "visit_cnt",
+            "thumbnail_url",
+            "rate_sum",
+            "rate",
+            "tags",
+        ]
 
-        read_only_fields = ["id", "name", "producer", "feedback_cnt", "review_cnt",
-                  "visit_cnt", "thumbnail_url", "rate_sum", "rate",  "tags"]
+        read_only_fields = [
+            "id",
+            "name",
+            "producer",
+            "category",
+            "feedback_cnt",
+            "review_cnt",
+            "visit_cnt",
+            "thumbnail_url",
+            "rate_sum",
+            "rate",
+            "tags",
+        ]


### PR DESCRIPTION
### 구현한 내용
- product_serializer를 통해 category 이름도 넘어가도록 수정하였습니다.
- * ProductSeralizer 내에 CategorySerializer라는 sub-serializer를 만들어 함께 묶어 보내는 방식으로 구현하였습니다.
### 논의할 내용
- 

### 추후 작업할 내용
- 
