### PR TITLE
fix: category serializer 삭제 및 category 이름 넘어가도록 수정

### DIFF
--- a/product/serializers/product_detail_serializer.py
+++ b/product/serializers/product_detail_serializer.py
@@ -1,15 +1,39 @@
 from rest_framework import serializers
 
 from product.models import Product
+from tag.serializers import TagSerializer
 from review.serializers import ReviewSerializer
-
 
 class ProductDetailSerializer(serializers.ModelSerializer):
     reviews = ReviewSerializer(many=True)
 
+    tags = TagSerializer(
+        read_only=False,
+        many=True,
+    )
+
+    category = serializers.CharField(
+        source = 'category.name'
+    )
+
     class Meta:
         model = Product
-        fields = "__all__"
+        fields = [
+            "id",
+            "category",
+            "name",
+            "producer",
+            "tags",
+            "codes",
+            "feedback_cnt",
+            "review_cnt",
+            "thumbnail_url",
+            "rate_sum",
+            "rate",
+            "liked_users",
+            "reviews",
+        ]
+
         read_only_fields = [
             "id",
             "feedback_cnt",

--- a/product/serializers/product_serializer.py
+++ b/product/serializers/product_serializer.py
@@ -1,18 +1,9 @@
-from rest_framework.serializers import ModelSerializer
+from rest_framework import serializers
 
 from product.models import Category, Product
 from tag.serializers import TagSerializer
 
-
-class CategorySerializer(ModelSerializer):
-    """Serializer definition for Category Model"""
-
-    model = Category
-    fields = ["name"]
-    read_only_fields = ["name"]
-
-
-class ProductSerializer(ModelSerializer):
+class ProductSerializer(serializers.ModelSerializer):
     """Serializer definition for Product Model."""
 
     tags = TagSerializer(
@@ -20,9 +11,8 @@ class ProductSerializer(ModelSerializer):
         many=True,
     )
 
-    category = CategorySerializer(
-        read_only=True,
-        many=False,
+    category = serializers.CharField(
+        source = "category.name"
     )
 
     class Meta:


### PR DESCRIPTION
### 구현한 내용
- category serializer 를 삭제하고 source 를 이용하여 이름이 넘어가도록 수정했습니다.
- 기존 product_detail_serializer 의 경우 tag와 category의 경우 이름이 아닌 id 가 넘어가고 있었어서 (serializer 없이 필드에만 담겨 있어서!) 이도 같이 수정했습니다.

