### PR TITLE
feat: 추천 검색어 반환되는 배열 수정

### DIFF
--- a/search/serializers/recommend_search_serializer.py
+++ b/search/serializers/recommend_search_serializer.py
@@ -6,12 +6,6 @@ from search.models import RecommendSearch
 class RecommendSearchSerializer(ModelSerializer):
     """Serializer definition for RecommendSearch Model."""
     
-    # '''Serializer로 전달된 quaryset으로 부터 value만 추출해 리스트로 만들어 리스트를 리턴'''
-    # def to_representation(self, instance):
-    #     original_data = super().to_representation(instance)
-    #     modified_data = [i.values() for i in len(original_data)+1]
-    #     return modified_data
-    
     class Meta:
         """Meta definition for RecommendSearchSerializer."""
 

--- a/search/serializers/recommend_search_serializer.py
+++ b/search/serializers/recommend_search_serializer.py
@@ -5,7 +5,13 @@ from search.models import RecommendSearch
 
 class RecommendSearchSerializer(ModelSerializer):
     """Serializer definition for RecommendSearch Model."""
-
+    
+    # '''Serializer로 전달된 quaryset으로 부터 value만 추출해 리스트로 만들어 리스트를 리턴'''
+    # def to_representation(self, instance):
+    #     original_data = super().to_representation(instance)
+    #     modified_data = [i.values() for i in len(original_data)+1]
+    #     return modified_data
+    
     class Meta:
         """Meta definition for RecommendSearchSerializer."""
 

--- a/search/views/search_api_view.py
+++ b/search/views/search_api_view.py
@@ -1,3 +1,5 @@
+import json
+
 from collections import Counter
 from datetime import datetime, timedelta
 
@@ -65,7 +67,8 @@ class SearchAPIView(ListAPIView):
         elif tab == "recommend":
             queryset = RecommendSearch.objects.all()
             serializer = RecommendSearchSerializer(queryset, many=True)
-            return Response(serializer.data, status=status.HTTP_200_OK)
+            value_list = [i.values() for i in serializer.data] #반복문을 최적화하는 방법이 어떤 게 있을까요? async 통한 비동기 처리...?
+            return Response(value_list, status=status.HTTP_200_OK)
 
         if category:
             products = products.filter(category__name=category)


### PR DESCRIPTION
### 구현한 내용
- 추천 검색어 url 접속시(api/search?tab=recommend) 반환되는 배열이 필드명을 제외하고 검색어로만 구성되게 수정하였습니다.

### 논의할 내용
- view 단에서 list comprehension을 사용하였는데 트래픽이 많아진다면 반드시 서버 부하가 가해질 것으로 예상됩니다.
- 따라서 async 이용한 비동기 처리를 고민해보려고 합니다. 

### 추후 작업할 내용
- 비동기 처리를 비롯해 for 문을 돌며 발생할 수 있는 부하를 줄일 수 있는 방안 찾고 고민해보기.
