### PR TITLE
fix: 임시로 code 와 tag 를 랜덤으로 추출하지 않도록 설정

### DIFF
--- a/webapp/product/views/magazine_api_view.py
+++ b/webapp/product/views/magazine_api_view.py
@@ -36,18 +36,18 @@ class MagazineAPIView(ListAPIView):
         c_type = ContentType.objects.get(app_label="product", model="product")
 
         if not code and not tag and not season:
-            codes = Code.objects.all()
-            randomCode = random.sample(list(codes), 2)
-            tags = Tag.objects.all()
-            randomTag = random.sample(list(tags), 2)
+            # codes = Code.objects.all()
+            # randomCode = random.sample(list(codes), 2)
+            # tags = Tag.objects.all()
+            # randomTag = random.sample(list(tags), 2)
             result = {
                 "codes": [],
                 "tags": [],
             }
 
-            for i in range(2):
-                result["codes"].append(randomCode[i].name)
-                result["tags"].append(randomTag[i].name)
+            # for i in range(2):
+            #     result["codes"].append(randomCode[i].name)
+            #     result["tags"].append(randomTag[i].name)
             return Response(result, status=status.HTTP_200_OK)
 
         elif code:


### PR DESCRIPTION
### 오류 났던 이유
```python
        if not code and not tag and not season:
            codes = Code.objects.all()
            randomCode = random.sample(list(codes), 2)
            tags = Tag.objects.all()
            randomTag = random.sample(list(tags), 2)
            result = {
                "codes": [],
                "tags": [],
            }

            for i in range(2):
                result["codes"].append(randomCode[i].name)
                result["tags"].append(randomTag[i].name)
            return Response(result, status=status.HTTP_200_OK)
```

- code 와 tag 를 랜덤으로 추출해야 하는데 db 에 code 와 tag 가 없어서 오류가 남
- 해당 코드를 머지할 당시에는 공유 db (db 서버)를 사용해서 문제 없다고 판단했던 것 같음

### 해결
- 임시로 codes 와 tags 배열이 빈 배열로 반환되도록 설정
- append 하는 부분을 임시로 주석 처리
- 이유 : 현재 db 에 데이터가 없으니 랜덤으로 추출하는 것도 불가능해서 불가피한 선택이라고 판단
